### PR TITLE
Issue #16: split artifact storage by source type

### DIFF
--- a/current.md
+++ b/current.md
@@ -96,6 +96,7 @@ notes:
 ## Specd
 
 - Unified Episode/Question Contract + No-Data-Loss Regression Gate | status: issued | issue: #14
+- Source-Split Artifact Storage Layout | status: issued | issue: #16
 
 ## Recovery Notes
 - Prior planning content was heavily compressed to reduce noise and keep active work scannable.

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -147,11 +147,13 @@ class Config(BaseModel):
         default_factory=lambda: {"EASY": 2, "MEDIUM": 2, "HARD": 4, "VERY_HARD": 6}
     )
 
-    # Outputs - separate paths for LLM vs synthetic pipelines
-    questions_llm_dir: str = "data/questions_llm"
-    questions_synthetic_dir: str = "data/questions_synthetic"
-    episodes_llm_jsonl: str = "data/episodes/episodes_llm.jsonl"
-    episodes_synthetic_jsonl: str = "data/episodes/episodes_synthetic.jsonl"
+    # Outputs - source-scoped paths
+    questions_template_dir: str = "data/questions/template"
+    questions_procedural_dir: str = "data/questions/procedural"
+    questions_llm_gen_dir: str = "data/questions/llm_gen"
+    episodes_template_jsonl: str = "data/episodes/template.jsonl"
+    episodes_procedural_jsonl: str = "data/episodes/procedural.jsonl"
+    episodes_llm_gen_jsonl: str = "data/episodes/llm_gen.jsonl"
 
     # Train/Test/Val Splitting
     split_seed: int = 42

--- a/src/datagen/episode_gen.py
+++ b/src/datagen/episode_gen.py
@@ -358,8 +358,9 @@ async def main(
     if output_path is None:
         ui.base.print_error(
             "ERROR: --output is required. Use one of:\n"
-            f"  --output {config.episodes_synthetic_jsonl}  (for synthetic questions)\n"
-            f"  --output {config.episodes_llm_jsonl}  (for LLM questions)"
+            f"  --output {config.episodes_template_jsonl}  (for template questions)\n"
+            f"  --output {config.episodes_procedural_jsonl}  (for procedural questions)\n"
+            f"  --output {config.episodes_llm_gen_jsonl}  (for LLM questions)"
         )
         return 1
     output_jsonl = Path(output_path)
@@ -372,8 +373,9 @@ async def main(
     if questions_dir is None:
         ui.base.print_error(
             "ERROR: --questions-dir is required. Use one of:\n"
-            f"  --questions-dir {config.questions_synthetic_dir}  (for synthetic questions)\n"
-            f"  --questions-dir {config.questions_llm_dir}  (for LLM questions)"
+            f"  --questions-dir {config.questions_template_dir}  (for template questions)\n"
+            f"  --questions-dir {config.questions_procedural_dir}  (for procedural questions)\n"
+            f"  --questions-dir {config.questions_llm_gen_dir}  (for LLM questions)"
         )
         return 1
     base_questions_dir = Path(questions_dir)

--- a/src/datagen/investigate.py
+++ b/src/datagen/investigate.py
@@ -27,7 +27,6 @@ from rich.table import Table
 from rich.panel import Panel
 
 
-
 console = Console()
 
 
@@ -64,7 +63,9 @@ def analyze_diagnostics_file(path: Path) -> dict:
         "categories": dict(categories),
         "by_category": by_category,
         "by_template": by_template,
-        "avg_entropy": sum(entropy_values) / len(entropy_values) if entropy_values else 0,
+        "avg_entropy": sum(entropy_values) / len(entropy_values)
+        if entropy_values
+        else 0,
     }
 
 
@@ -107,8 +108,7 @@ def print_template_breakdown(analysis: dict) -> None:
     table.add_column("Fail%", justify="right")
 
     for template, counts in sorted(
-        analysis["by_template"].items(),
-        key=lambda x: -sum(x[1].values())
+        analysis["by_template"].items(), key=lambda x: -sum(x[1].values())
     )[:15]:  # Top 15 templates
         total = sum(counts.values())
         good = counts.get("good", 0)
@@ -167,9 +167,11 @@ async def run_diagnostic_batch(
     from src.core.prompts import generate_data_overview
 
     # Find a dataset with questions
-    questions_dir = Path("data/questions_synthetic")
+    questions_dir = Path("data/questions/template")
     if not questions_dir.exists():
-        console.print("[red]No synthetic questions found. Run question generation first.[/red]")
+        console.print(
+            "[red]No synthetic questions found. Run question generation first.[/red]"
+        )
         raise SystemExit(1)
 
     # Get first available dataset
@@ -193,13 +195,21 @@ async def run_diagnostic_batch(
 
     # Filter by template if specified
     if template_filter:
-        questions = [q for q in questions if template_filter.lower() in q.get("template_name", "").lower()]
+        questions = [
+            q
+            for q in questions
+            if template_filter.lower() in q.get("template_name", "").lower()
+        ]
         if not questions:
-            console.print(f"[red]No questions matching template filter: {template_filter}[/red]")
+            console.print(
+                f"[red]No questions matching template filter: {template_filter}[/red]"
+            )
             raise SystemExit(1)
 
     questions = questions[:limit]
-    console.print(f"[bold]Running diagnostic batch on {len(questions)} questions from {dataset_dir.name}[/bold]")
+    console.print(
+        f"[bold]Running diagnostic batch on {len(questions)} questions from {dataset_dir.name}[/bold]"
+    )
 
     # Generate data overview
     data_overview = generate_data_overview(str(csv_path))
@@ -227,7 +237,10 @@ async def run_diagnostic_batch(
         for r in results:
             if r.diagnostics:
                 record = {
-                    "question": (r.question.get("question_text") or r.question.get("question", ""))[:200],
+                    "question": (
+                        r.question.get("question_text")
+                        or r.question.get("question", "")
+                    )[:200],
                     "template_name": r.question.get("template_name"),
                     "difficulty": r.question.get("difficulty"),
                     "verified": r.verified,
@@ -265,42 +278,46 @@ Examples:
     )
 
     parser.add_argument(
-        "--batch", action="store_true",
-        help="Run a diagnostic batch on synthetic questions"
+        "--batch",
+        action="store_true",
+        help="Run a diagnostic batch on synthetic questions",
     )
     parser.add_argument(
-        "--limit", type=int, default=10,
-        help="Number of questions to process (default: 10)"
+        "--limit",
+        type=int,
+        default=10,
+        help="Number of questions to process (default: 10)",
     )
     parser.add_argument(
-        "--template", type=str,
-        help="Filter questions by template name (substring match)"
+        "--template",
+        type=str,
+        help="Filter questions by template name (substring match)",
     )
     parser.add_argument(
-        "--analyze", type=Path,
-        help="Analyze diagnostics from a JSONL file"
+        "--analyze", type=Path, help="Analyze diagnostics from a JSONL file"
     )
     parser.add_argument(
-        "--summary", type=Path,
-        help="Show summary statistics from a JSONL file"
+        "--summary", type=Path, help="Show summary statistics from a JSONL file"
     )
     parser.add_argument(
-        "--examples", type=str,
-        help="Show example failures for a category (e.g., 'ambiguous')"
+        "--examples",
+        type=str,
+        help="Show example failures for a category (e.g., 'ambiguous')",
     )
     parser.add_argument(
-        "--output", type=Path,
-        help="Output path for diagnostic results"
+        "--output", type=Path, help="Output path for diagnostic results"
     )
 
     args = parser.parse_args()
 
     if args.batch:
-        output_path = asyncio.run(run_diagnostic_batch(
-            limit=args.limit,
-            output_path=args.output,
-            template_filter=args.template,
-        ))
+        output_path = asyncio.run(
+            run_diagnostic_batch(
+                limit=args.limit,
+                output_path=args.output,
+                template_filter=args.template,
+            )
+        )
         # Auto-analyze the results
         analysis = analyze_diagnostics_file(output_path)
         console.print()

--- a/src/datagen/question_gen.py
+++ b/src/datagen/question_gen.py
@@ -42,7 +42,7 @@ def get_datasets_with_episodes() -> set[str]:
     Returns set of csv paths that have episodes generated.
     Used to prevent accidental question regeneration.
     """
-    episodes_path = Path(config.episodes_llm_jsonl)
+    episodes_path = Path(config.episodes_llm_gen_jsonl)
     if not episodes_path.exists():
         return set()
 
@@ -465,7 +465,7 @@ async def run_parallel_generation(
     max_tokens = config.sampling_args.max_tokens
     model = config.question_gen_model
     max_turns = config.question_gen_max_turns
-    base_output_dir = Path(config.questions_llm_dir)
+    base_output_dir = Path(config.questions_llm_gen_dir)
 
     # Check for existing episodes (lock mechanism)
     datasets_with_episodes = get_datasets_with_episodes() if not regenerate else set()

--- a/src/datagen/synthetic/generator.py
+++ b/src/datagen/synthetic/generator.py
@@ -720,7 +720,7 @@ async def generate_questions(
     # Prepare output path early for incremental saving
     if output_dir is None:
         dataset_name = Path(csv_path).parent.name
-        output_dir = f"{config.questions_synthetic_dir}/{dataset_name}"
+        output_dir = f"{config.questions_template_dir}/{dataset_name}"
     output_path = Path(output_dir)
     output_path.mkdir(parents=True, exist_ok=True)
 

--- a/src/datagen/synthetic/programs/program_generator.py
+++ b/src/datagen/synthetic/programs/program_generator.py
@@ -244,7 +244,7 @@ async def run_pipeline(
     output_path = (
         Path(output_dir)
         if output_dir
-        else Path("data/questions_synthetic") / dataset_name
+        else Path(config.questions_procedural_dir) / dataset_name
     )
     output_path.mkdir(parents=True, exist_ok=True)
 

--- a/src/datagen/validate_question.py
+++ b/src/datagen/validate_question.py
@@ -8,7 +8,7 @@ Usage:
     # From a questions file:
     uv run python -m src.datagen.validate_question \
         --csv data/csv/data.csv \
-        --questions-file data/questions_synthetic/marketing-data/questions.json \
+        --questions-file data/questions/template/marketing-data/questions.json \
         --index 0
 
     # Custom question:

--- a/src/datagen/validate_synthetic.py
+++ b/src/datagen/validate_synthetic.py
@@ -2,7 +2,7 @@
 Synthetic episode generation pipeline.
 
 This script validates synthetic questions by running a single teacher trace:
-1. Loads questions from questions_synthetic_dir
+1. Loads questions from a source-scoped questions directory
 2. Runs 1 teacher trace per question (WITH hint)
 3. Validates answer matches ground_truth_hash
 4. Saves successful episodes to disk, logs failures
@@ -12,13 +12,13 @@ have known ground truth from template execution.
 
 Usage:
     uv run python -m src.datagen.validate_synthetic \
-        --questions-dir data/questions_synthetic \
-        --output data/episodes/episodes_synthetic.jsonl
+        --questions-dir data/questions/template \
+        --output data/episodes/template.jsonl
 
     # Parallel mode (process multiple datasets concurrently)
     uv run python -m src.datagen.validate_synthetic \
-        --questions-dir data/questions_synthetic \
-        --output data/episodes/episodes_synthetic.jsonl \
+        --questions-dir data/questions/procedural \
+        --output data/episodes/procedural.jsonl \
         --parallel --n-workers 4
 """
 
@@ -607,13 +607,13 @@ if __name__ == "__main__":
         "--questions-dir",
         type=str,
         required=True,
-        help="Directory containing question files (e.g., data/questions_synthetic)",
+        help="Directory containing question files (e.g., data/questions/template)",
     )
     parser.add_argument(
         "--output",
         type=str,
         required=True,
-        help="Output JSONL file path (e.g., data/episodes/episodes_synthetic.jsonl)",
+        help="Output JSONL file path (e.g., data/episodes/template.jsonl)",
     )
     parser.add_argument(
         "--max-questions",

--- a/src/gui/state.py
+++ b/src/gui/state.py
@@ -57,12 +57,14 @@ class AppState:
     # Pipeline execution
     pipeline: PipelineProgress = field(default_factory=PipelineProgress)
     process: Popen | None = None
-    progress_file: Path = field(default_factory=lambda: Path("/tmp/claude/gui_progress.json"))
+    progress_file: Path = field(
+        default_factory=lambda: Path("/tmp/claude/gui_progress.json")
+    )
 
     # Data paths
     data_dir: Path = field(default_factory=lambda: Path("data"))
     csv_sources: list[Path] = field(default_factory=list)
-    questions_dir: Path = field(default_factory=lambda: Path("data/questions_synthetic"))
+    questions_dir: Path = field(default_factory=lambda: Path("data/questions/template"))
     episodes_dir: Path = field(default_factory=lambda: Path("data/episodes"))
 
     # Selected items

--- a/src/training/split_episodes.py
+++ b/src/training/split_episodes.py
@@ -224,7 +224,7 @@ def main():
         "--input",
         type=str,
         required=True,
-        help="Input episodes JSONL file (e.g., data/episodes/episodes_synthetic.jsonl)",
+        help="Input episodes JSONL file (e.g., data/episodes/template.jsonl)",
     )
     parser.add_argument(
         "--output-dir",


### PR DESCRIPTION
## Summary
- migrate runtime artifact paths to source-scoped layout for `template`, `procedural`, and `llm_gen`
- remove mixed synthetic output paths from active runtime usage and simplify preflight semantics
- add fail-fast detection for deprecated legacy layout paths with explicit migration guidance

## Source-scoped layout
### Questions
- `data/questions/template/<dataset>/questions.json`
- `data/questions/procedural/<dataset>/questions.json`
- `data/questions/llm_gen/<dataset>/questions.json`

### Episodes
- `data/episodes/template.jsonl`
- `data/episodes/procedural.jsonl`
- `data/episodes/llm_gen.jsonl`

## Key changes
- `src/core/config.py`: new source-scoped path config fields
- `src/cli.py`: preflight + generation now target source-specific paths; legacy mixed layout fails fast
- `src/datagen/pipeline.py`: template/procedural/llm stages write to separate outputs
- `src/utils/stats.py` and `src/utils/inspect.py`: read from source-scoped paths
- `src/datagen/synthetic/generator.py` and `src/datagen/synthetic/programs/program_generator.py`: default question output paths updated
- tests updated/added in `tests/test_cli_entrypoint_contract.py`

## Validation
- `uv run ruff check src tests`
- `uv run pytest -q`

Fixes #16