### PR TITLE
refactor: remove dead investigate runtime entrypoint

### DIFF
--- a/scripts/experiments/README.md
+++ b/scripts/experiments/README.md
@@ -2,3 +2,5 @@ Experimental and ad-hoc analysis scripts.
 
 These are intentionally not part of the automated `tests/` suite.
 Run them manually when needed.
+
+- `investigate_failures.py`: ad-hoc failure diagnostics for triangulation output.


### PR DESCRIPTION
## Summary
- remove the unreferenced `src/datagen/investigate.py` runtime module entrypoint after validating there are no runtime callsites
- keep the utility available as an ad-hoc script by relocating it to `scripts/experiments/investigate_failures.py`
- update `scripts/experiments/README.md` to document the retained ad-hoc diagnostics utility

## Validation
- `uv run ruff check .` *(fails on pre-existing lint debt in unrelated scripts; no new lint failures introduced by this change)*
- `uv run pytest tests/test_triangulation.py tests/test_strict_answer_contract.py`
- `uv run pytest`

Closes #23