### PR TITLE
refactor: unify source-scoped artifact path resolution

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -111,7 +111,6 @@ def cmd_progress():
     import json
     from datetime import datetime
 
-    from src.core.config import config
     from src.utils.stats import collect_questions_stats, collect_episodes_stats
 
     q_stats = collect_questions_stats()
@@ -964,7 +963,6 @@ def cmd_analyze(
 def cmd_manifest_summary():
     """Show manifest summary - cached questions and template changes."""
     from src.datagen.manifest import DatagenManifest, compute_dataset_hash
-    from src.core.config import config
 
     manifest = DatagenManifest()
     manifest.load()

--- a/src/core/paths.py
+++ b/src/core/paths.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+from typing import Literal
+
+from src.core.config import Config, config
+
+ArtifactSource = Literal["template", "procedural", "llm_gen"]
+
+
+def _normalize_source(source: str) -> ArtifactSource:
+    if source == "template":
+        return "template"
+    if source == "procedural":
+        return "procedural"
+    if source == "llm_gen":
+        return "llm_gen"
+    raise ValueError(
+        f"Invalid artifact source: {source!r}. Expected one of: template, procedural, llm_gen"
+    )
+
+
+def resolve_questions_dir(source: str, cfg: Config = config) -> Path:
+    normalized = _normalize_source(source)
+    if normalized == "template":
+        return Path(cfg.questions_template_dir)
+    if normalized == "procedural":
+        return Path(cfg.questions_procedural_dir)
+    return Path(cfg.questions_llm_gen_dir)
+
+
+def resolve_episodes_file(source: str, cfg: Config = config) -> Path:
+    normalized = _normalize_source(source)
+    if normalized == "template":
+        return Path(cfg.episodes_template_jsonl)
+    if normalized == "procedural":
+        return Path(cfg.episodes_procedural_jsonl)
+    return Path(cfg.episodes_llm_gen_jsonl)
+
+
+def resolve_all_question_dirs(cfg: Config = config) -> list[Path]:
+    return [
+        resolve_questions_dir("template", cfg),
+        resolve_questions_dir("procedural", cfg),
+        resolve_questions_dir("llm_gen", cfg),
+    ]
+
+
+def resolve_all_episode_files(cfg: Config = config) -> list[Path]:
+    return [
+        resolve_episodes_file("template", cfg),
+        resolve_episodes_file("procedural", cfg),
+        resolve_episodes_file("llm_gen", cfg),
+    ]

--- a/src/utils/inspect.py
+++ b/src/utils/inspect.py
@@ -18,6 +18,8 @@ from rich.table import Table
 from rich.panel import Panel
 from rich.syntax import Syntax
 
+from src.core.paths import resolve_all_episode_files, resolve_questions_dir
+
 
 console = Console()
 
@@ -31,16 +33,16 @@ def inspect_questions(
 ):
     """Preview generated questions."""
     if source == "template":
-        questions_dirs = [Path("data/questions/template")]
+        questions_dirs = [resolve_questions_dir("template")]
     elif source == "procedural":
-        questions_dirs = [Path("data/questions/procedural")]
+        questions_dirs = [resolve_questions_dir("procedural")]
     elif source == "llm_gen":
-        questions_dirs = [Path("data/questions/llm_gen")]
+        questions_dirs = [resolve_questions_dir("llm_gen")]
     else:  # all
         questions_dirs = [
-            Path("data/questions/template"),
-            Path("data/questions/procedural"),
-            Path("data/questions/llm_gen"),
+            resolve_questions_dir("template"),
+            resolve_questions_dir("procedural"),
+            resolve_questions_dir("llm_gen"),
         ]
 
     files = []
@@ -134,11 +136,7 @@ def inspect_episodes(
         episodes_file = Path(output)
     else:
         # Try source-scoped files
-        candidates = [
-            Path("data/episodes/template.jsonl"),
-            Path("data/episodes/procedural.jsonl"),
-            Path("data/episodes/llm_gen.jsonl"),
-        ]
+        candidates = resolve_all_episode_files()
         episodes_file = None
         for c in candidates:
             if c.exists():
@@ -227,11 +225,7 @@ def inspect_trace(episode_id: str, output: str | None = None):
     if output:
         episodes_file = Path(output)
     else:
-        candidates = [
-            Path("data/episodes/template.jsonl"),
-            Path("data/episodes/procedural.jsonl"),
-            Path("data/episodes/llm_gen.jsonl"),
-        ]
+        candidates = resolve_all_episode_files()
         episodes_file = None
         for c in candidates:
             if c.exists():

--- a/src/utils/stats.py
+++ b/src/utils/stats.py
@@ -17,6 +17,8 @@ from rich.console import Console
 from rich.table import Table
 from rich.panel import Panel
 
+from src.core.paths import resolve_episodes_file, resolve_questions_dir
+
 
 console = Console()
 
@@ -35,8 +37,8 @@ def collect_questions_stats() -> dict:
 
     # Synthetic questions (template + procedural)
     synthetic_dirs = [
-        Path("data/questions/template"),
-        Path("data/questions/procedural"),
+        resolve_questions_dir("template"),
+        resolve_questions_dir("procedural"),
     ]
     for synth_dir in synthetic_dirs:
         if not synth_dir.exists():
@@ -57,7 +59,7 @@ def collect_questions_stats() -> dict:
                 stats["synthetic"]["by_template"][template] += 1
 
     # LLM questions
-    llm_dir = Path("data/questions/llm_gen")
+    llm_dir = resolve_questions_dir("llm_gen")
     if llm_dir.exists():
         for qf in llm_dir.glob("*/questions.json"):
             dataset = qf.parent.name
@@ -94,8 +96,8 @@ def collect_episodes_stats() -> dict:
 
     # Synthetic episodes (template + procedural)
     for synth_file in [
-        Path("data/episodes/template.jsonl"),
-        Path("data/episodes/procedural.jsonl"),
+        resolve_episodes_file("template"),
+        resolve_episodes_file("procedural"),
     ]:
         if not synth_file.exists():
             continue
@@ -117,7 +119,7 @@ def collect_episodes_stats() -> dict:
                 stats["synthetic"]["by_difficulty"][diff] += 1
 
     # LLM episodes
-    llm_file = Path("data/episodes/llm_gen.jsonl")
+    llm_file = resolve_episodes_file("llm_gen")
     if llm_file.exists():
         with open(llm_file) as f:
             for line in f:

--- a/tests/test_artifact_path_resolver.py
+++ b/tests/test_artifact_path_resolver.py
@@ -1,0 +1,216 @@
+import json
+
+import pytest
+
+from src.core.paths import (
+    resolve_all_episode_files,
+    resolve_episodes_file,
+    resolve_questions_dir,
+)
+from src.datagen import pipeline as pipeline_module
+from src.utils.inspect import inspect_episodes
+from src.utils.stats import collect_episodes_stats, collect_questions_stats
+
+
+@pytest.mark.parametrize(
+    "source, expected_questions_dir, expected_episodes_file",
+    [
+        ("template", "data/questions/template", "data/episodes/template.jsonl"),
+        ("procedural", "data/questions/procedural", "data/episodes/procedural.jsonl"),
+        ("llm_gen", "data/questions/llm_gen", "data/episodes/llm_gen.jsonl"),
+    ],
+)
+def test_resolver_returns_source_scoped_paths(
+    source: str, expected_questions_dir: str, expected_episodes_file: str
+):
+    assert str(resolve_questions_dir(source)) == expected_questions_dir
+    assert str(resolve_episodes_file(source)) == expected_episodes_file
+
+
+@pytest.mark.parametrize("invalid_source", ["all", "synthetic", "", "LLM"])
+def test_resolver_fail_fast_on_invalid_source(invalid_source: str):
+    with pytest.raises(ValueError, match="Invalid artifact source"):
+        resolve_questions_dir(invalid_source)
+
+    with pytest.raises(ValueError, match="Invalid artifact source"):
+        resolve_episodes_file(invalid_source)
+
+
+def test_stats_collectors_preserve_source_scoped_layout_semantics(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+
+    template_q = tmp_path / "data/questions/template/demo/questions.json"
+    procedural_q = tmp_path / "data/questions/procedural/demo/questions.json"
+    llm_q = tmp_path / "data/questions/llm_gen/demo/questions.json"
+    template_q.parent.mkdir(parents=True, exist_ok=True)
+    procedural_q.parent.mkdir(parents=True, exist_ok=True)
+    llm_q.parent.mkdir(parents=True, exist_ok=True)
+
+    template_q.write_text(
+        json.dumps(
+            {
+                "questions": [
+                    {
+                        "source": "template",
+                        "difficulty": "EASY",
+                        "template_name": "mean",
+                    }
+                ]
+            }
+        )
+    )
+    procedural_q.write_text(
+        json.dumps(
+            {
+                "questions": [
+                    {
+                        "source": "procedural",
+                        "difficulty": "MEDIUM",
+                        "template_name": "group_by",
+                    }
+                ]
+            }
+        )
+    )
+    llm_q.write_text(
+        json.dumps(
+            {
+                "questions": [
+                    {
+                        "source": "llm_gen",
+                        "difficulty": "HARD",
+                    }
+                ]
+            }
+        )
+    )
+
+    template_episodes = tmp_path / "data/episodes/template.jsonl"
+    llm_episodes = tmp_path / "data/episodes/llm_gen.jsonl"
+    template_episodes.parent.mkdir(parents=True, exist_ok=True)
+    template_episodes.write_text(
+        json.dumps(
+            {
+                "verified": True,
+                "csv_source": "data/kaggle/demo/data.csv",
+                "question": {"difficulty": "EASY"},
+            }
+        )
+        + "\n"
+    )
+    llm_episodes.write_text(
+        json.dumps(
+            {
+                "verified": False,
+                "csv_source": "data/kaggle/demo/data.csv",
+                "question": {"difficulty": "HARD"},
+            }
+        )
+        + "\n"
+    )
+
+    q_stats = collect_questions_stats()
+    e_stats = collect_episodes_stats()
+
+    assert q_stats["synthetic"]["total"] == 2
+    assert q_stats["llm"]["total"] == 1
+    assert q_stats["synthetic"]["by_dataset"]["demo"] == 1
+    assert q_stats["llm"]["by_dataset"]["demo"] == 1
+
+    assert e_stats["synthetic"]["total"] == 1
+    assert e_stats["synthetic"]["verified"] == 1
+    assert e_stats["llm"]["total"] == 1
+    assert e_stats["llm"]["verified"] == 0
+
+
+def test_inspect_episodes_default_candidate_order_is_preserved(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.chdir(tmp_path)
+
+    template_file, _, llm_file = [
+        tmp_path / p
+        for p in [
+            str(resolve_all_episode_files()[0]),
+            str(resolve_all_episode_files()[1]),
+            str(resolve_all_episode_files()[2]),
+        ]
+    ]
+    template_file.parent.mkdir(parents=True, exist_ok=True)
+    template_file.write_text(
+        json.dumps(
+            {
+                "episode_id": "template-1",
+                "verified": True,
+                "question": {"question_text": "q"},
+                "gold_trace": {"turns": [], "final_answer": 1},
+            }
+        )
+        + "\n"
+    )
+    llm_file.write_text(
+        json.dumps(
+            {
+                "episode_id": "llm-1",
+                "verified": True,
+                "question": {"question_text": "q"},
+                "gold_trace": {"turns": [], "final_answer": 1},
+            }
+        )
+        + "\n"
+    )
+
+    inspect_episodes(output=None, count=1, verified=False, show_hooks=False)
+    out = capsys.readouterr().out
+
+    assert "template.jsonl" in out
+
+
+def test_pipeline_uses_resolver_paths_for_stage_arguments(monkeypatch):
+    stage_calls: list[tuple[str, list[str]]] = []
+    synth_calls: list[tuple[str, str, str, int | None, str]] = []
+
+    def _fake_run_stage(name: str, cmd: list[str]) -> bool:
+        stage_calls.append((name, cmd))
+        return True
+
+    def _fake_run_synthetic_stage(
+        name: str,
+        questions_dir: str,
+        output_path: str,
+        max_questions: int | None,
+        source: str,
+    ) -> bool:
+        synth_calls.append((name, questions_dir, output_path, max_questions, source))
+        return True
+
+    monkeypatch.setattr(pipeline_module, "run_stage", _fake_run_stage)
+    monkeypatch.setattr(
+        pipeline_module, "run_synthetic_stage", _fake_run_synthetic_stage
+    )
+
+    rc = pipeline_module.main(mode="all", test=False, max_questions=5)
+
+    assert rc == 0
+    assert (
+        "Stage 2a: Generate Template Episodes",
+        "data/questions/template",
+        "data/episodes/template.jsonl",
+        5,
+        "template",
+    ) in synth_calls
+    assert (
+        "Stage 2b: Generate Procedural Episodes",
+        "data/questions/procedural",
+        "data/episodes/procedural.jsonl",
+        5,
+        "procedural",
+    ) in synth_calls
+
+    llm_stage = dict(stage_calls)["Stage 2c: Generate LLM Episodes"]
+    assert "--questions-dir" in llm_stage
+    assert "data/questions/llm_gen" in llm_stage
+    assert "--output" in llm_stage
+    assert "data/episodes/llm_gen.jsonl" in llm_stage


### PR DESCRIPTION
## Summary
- add a shared resolver module in `src/core/paths.py` for source-scoped question and episode artifact locations
- migrate CLI, stats, inspect, and pipeline consumers to use the resolver instead of duplicated hardcoded paths
- add resolver and regression tests to lock path outputs, invalid-source fail-fast behavior, and consumer path usage

## Testing
- `uv run ruff check src/core/paths.py src/cli.py src/utils/stats.py src/utils/inspect.py src/datagen/pipeline.py tests/test_artifact_path_resolver.py`
- `uv run pytest tests/test_artifact_path_resolver.py tests/test_cli_entrypoint_contract.py`
- `uv run pytest`

Closes #24