### PR TITLE
test: remove avoidable skips in default pytest run

### DIFF
--- a/data/fixtures/multi_outcome_episode.json
+++ b/data/fixtures/multi_outcome_episode.json
@@ -1,0 +1,90 @@
+{
+  "episode_id": "fixture-multi-outcome-001",
+  "timestamp": "2025-01-01T00:00:00.000000",
+  "csv_source": "data/mock/data.csv",
+  "verified": true,
+  "question": {
+    "id": "q-multi-outcome-001",
+    "question_text": "What is the representative answer for this controlled ambiguity fixture?",
+    "hint": "Either canonical form is accepted",
+    "difficulty": "MEDIUM",
+    "n_steps": 1,
+    "template_name": "fixture_multi_outcome",
+    "template_params": {},
+    "output_type": "dict",
+    "output_schema": null,
+    "ground_truth": {
+      "answer": 42
+    },
+    "ground_truth_hash": "multihash-aaa111",
+    "ground_truth_hashes": [
+      "multihash-aaa111",
+      "multihash-bbb222"
+    ]
+  },
+  "gold_trace": {
+    "turns": [
+      {
+        "turn_index": 0,
+        "reasoning": "Fixture response with one valid hash",
+        "code": "submit({'answer': 42})",
+        "execution": {
+          "success": true,
+          "stdout": "✓ Submitted: {\"__csv_agent_answer__\": {\"answer\": 42}, \"hooks\": []}",
+          "stderr": "",
+          "hooks": [],
+          "submitted_answer": {
+            "answer": 42
+          }
+        },
+        "correction": null
+      }
+    ],
+    "final_answer": {
+      "answer": 42
+    },
+    "final_answer_hash": "multihash-aaa111",
+    "success": true
+  },
+  "consistency_traces": [
+    {
+      "turns": [
+        {
+          "turn_index": 0,
+          "reasoning": null,
+          "code": "submit({'answer': 42})",
+          "execution": {
+            "success": true,
+            "stdout": "✓ Submitted: {\"__csv_agent_answer__\": {\"answer\": 42}, \"hooks\": []}",
+            "stderr": "",
+            "hooks": [],
+            "submitted_answer": {
+              "answer": 42
+            }
+          },
+          "correction": null
+        }
+      ],
+      "final_answer": {
+        "answer": 42
+      },
+      "final_answer_hash": "multihash-bbb222",
+      "success": true
+    }
+  ],
+  "triangulation": {
+    "n_consistency_runs": 1,
+    "n_consistency_succeeded": 1,
+    "majority_answer_hash": "multihash-aaa111",
+    "majority_count": 1,
+    "gold_matches_majority": true
+  },
+  "timing": {
+    "gold_elapsed": 1.0,
+    "consistency_elapsed": [
+      0.9
+    ],
+    "total_elapsed": 1.9,
+    "avg_elapsed": 0.95
+  }
+}

--- a/tests/test_container_pool.py
+++ b/tests/test_container_pool.py
@@ -304,7 +304,7 @@ class TestContainerPool:
         from pathlib import Path
 
         # Skip if second CSV doesn't exist
-        csv2 = Path("data/kaggle/breast-cancer/data.csv")
+        csv2 = Path("data/mock/data.csv")
         if not csv2.exists():
             pytest.skip("Second test CSV not available")
 

--- a/tests/test_programs_smoke.py
+++ b/tests/test_programs_smoke.py
@@ -10,7 +10,7 @@ from src.datagen.synthetic.programs.operators import get_operator
 from src.envs.csv_env import LocalCSVAnalysisEnv
 from pathlib import Path
 
-DATA_CSV = Path("data/csv/data.csv")
+DATA_CSV = Path("data/mock/data.csv")
 
 
 @pytest_asyncio.fixture(scope="module")


### PR DESCRIPTION
## Summary
- close #29 by removing avoidable skips caused by optional local-only fixtures
- switch skip-prone tests to committed datasets/fixtures so they execute deterministically in CI
- keep intentional skips (GPU-only and explicitly deferred FakeLLM triangulation integration) unchanged

## Changes
- `tests/test_container_pool.py`: use `data/mock/data.csv` as the second CSV for container switching test
- `tests/test_programs_smoke.py`: use `data/mock/data.csv` so binary-categorical coverage test runs
- add `data/fixtures/multi_outcome_episode.json` for multi-outcome episode contract tests

## Validation
- `uv run pytest tests/test_container_pool.py::TestContainerPool::test_pool_acquire_different_csv tests/test_episode_contract.py::TestMultiOutcomeEpisodes tests/test_programs_smoke.py::TestProgramCompilation::test_system2_coverage -q -rs`
- `uv run pytest -q -rs` → `307 passed, 2 skipped`
- `uv run ruff check tests/test_container_pool.py tests/test_programs_smoke.py`
